### PR TITLE
Rewrite URL for the save function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ yarn-error.log*
 # Docs
 /docs/_site
 /docs/.sass-cache
+
+# IDE
+/.idea
+*.iml

--- a/src/resource.js
+++ b/src/resource.js
@@ -101,7 +101,7 @@ function makeSave<T: { id: ?number }>(DomainClass: Class<T>, baseUrl: string): (
         return merge(this, json);
       });
     } else {
-      return post(`api/pokemon`, this).then((json: any) => {
+      return post(`${baseUrl}`, this).then((json: any) => {
         return merge(this, json);
       });
     }


### PR DESCRIPTION
When a Resource is saved, either a PUT or POST request is made
to the back-end. In the case of the POST request the URL
/api/pokemon was used instead of using the baseURL.