### PR TITLE
Upgrade/flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,6 +6,3 @@
 /flow-typed/
 
 [libs]
-
-[options]
-unsafe.enable_getters_and_setters=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2018-01-15
+
+### Added
+- The first version of this library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mad-spring-connect",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1312,9 +1312,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.54.1",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.54.1.tgz",
-      "integrity": "sha1-cQG8zPAG3AZScUqK7wxyB4p2BRA=",
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.63.1.tgz",
+      "integrity": "sha512-aWKHYs3UECgpwrIDVUiABjSC8dgaKmonymQDWO+6FhGcp9lnnxdDBE6Sfm3F7YaRPfLYsWAY4lndBrfrfyn+9g==",
       "dev": true
     },
     "flow-copy-source": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mad-spring-connect",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Connecting with a Spring REST APIs in a domain friendly manner",
   "files": [
     "lib"
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "start": "jest test --watch",
-    "test": "npm run flow -- version && npm run flow && jest test --coverage",
+    "test": "npm run flow && jest test --coverage",
     "flow": "flow version && flow",
     "prepublish": "rm -rf lib && npm test && npm run babel-prepublish && npm run flow-prepublish",
     "babel-prepublish": "babel src/ -d lib",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-es2015": "6.22.0",
     "babel-preset-react": "6.23.0",
     "babel-runtime": "6.23.0",
-    "flow-bin": "0.54.1",
+    "flow-bin": "0.63.1",
     "flow-copy-source": "1.1.0",
     "jest": "20.0.4",
     "react": "15.4.2",
@@ -49,7 +49,7 @@
   "scripts": {
     "start": "jest test --watch",
     "test": "npm run flow -- version && npm run flow && jest test --coverage",
-    "flow": "flow",
+    "flow": "flow version && flow",
     "prepublish": "rm -rf lib && npm test && npm run babel-prepublish && npm run flow-prepublish",
     "babel-prepublish": "babel src/ -d lib",
     "flow-prepublish": "flow-copy-source src lib"

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ let config: Config = {
 };
 
 /**
- * Configures the MadConnect libary.
+ * Configures the MadConnect library.
  *
  * @param {Config} The new configuration
  */
@@ -33,7 +33,7 @@ export function getConfig(): Config {
 }
 
 /**
- * Convienence function to return 'fetch' from the config.
+ * Convenience function to return 'fetch' from the config.
  * 
  * Returns either a custom fetch implementation provider by
  * the user via 'configureMadConnect' or the default fetch
@@ -47,7 +47,7 @@ export function getFetch(): typeof fetch {
 }
 
 /**
- * Convienence function to return the 'middleware' from the config.
+ * Convenience function to return the 'middleware' from the config.
  * 
  * @export
  * @returns {Array<Middleware>} The currently configured middleware

--- a/src/resource.js
+++ b/src/resource.js
@@ -26,10 +26,12 @@ export interface Resource<T> {
   
   save(): Promise<T>;
   remove(): Promise<T>;
+}
 
-  static one(id: number, queryParams: ?Object): Promise<T>;
-  static list(queryParams: ?Object): Promise<Array<T>>;
-  static page(queryParams: ?Object): Promise<Page<T>>;
+export type StaticResource<T> = {
+  one(id: number, queryParams: ?Object): Promise<T>;
+  list(queryParams: ?Object): Promise<Array<T>>;
+  page(queryParams: ?Object): Promise<Page<T>>;
 }
 
 /**
@@ -38,7 +40,7 @@ export interface Resource<T> {
  * interface.
  * 
  * Adds the following instance methods: `save` and `remove`.
- * Adds the following static methdos: `one`, `list` and `page`.
+ * Adds the following static methods: `one`, `list` and `page`.
  * 
  * It will not override instance, and static method if they are
  * already defined.
@@ -46,7 +48,7 @@ export interface Resource<T> {
  * @example
  * ```js
  * class Pokemon {
- *   id: ?number;
+ *   id: number;
  *   name: string;
  *   types: Array<string>;
  * }
@@ -58,7 +60,7 @@ export interface Resource<T> {
  * @param { Class<T : { id: ?number }> } DomainClass A class definition representing a domain entity. The entity must have an id field.
  * @param {string} baseUrl The part of the url which is constant, for example 'api/pokemon/';
  */
-export function makeResource<T>(DomainClass: *, baseUrl: string) {
+export function makeResource<T>(DomainClass: *, baseUrl: string): Resource<T> & StaticResource<T> {
   if (DomainClass.prototype.save === undefined) {
     DomainClass.prototype.save = makeSave(DomainClass, baseUrl);
   }
@@ -78,6 +80,8 @@ export function makeResource<T>(DomainClass: *, baseUrl: string) {
   if (DomainClass.page === undefined) {
     DomainClass.page = makePage(DomainClass, baseUrl);
   }
+
+  return DomainClass;
 }
 
 function makeSave<T: { id: ?number }>(DomainClass: Class<T>, baseUrl: string): () => Promise<T> {


### PR DESCRIPTION
 Updated flow to `0.63.1`.
    
 Flow version `0.63.1` does not support static methods in interfaces
 anymore, had to changed the definitions by putting all static methods
 in a separate `StaticResource` type definition.