### PR TITLE
Bugfix:  Fixed a bug which caused the `emptyPage`to be recognized as …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug which caused the `emptyPage` from the spring-models not
+to be recognized as being of type Page<T>. This caused flow errors when
+using the `emptyPage` more than once in an application.
+
 ## [1.0.0] - 2018-01-15
 
 ### Added

--- a/src/spring-models.js
+++ b/src/spring-models.js
@@ -19,7 +19,7 @@ export type Page<T> = {
  * Represents an empty Page useful for initializing variables while
  * waiting for the actual Page to be retrieved.
  */
-export const emptyPage = Object.freeze({
+export const emptyPage: Page<*> = Object.freeze({
   content: [],
   last: true,
   totalElements: 0,

--- a/tests/spring-models.test.js
+++ b/tests/spring-models.test.js
@@ -1,0 +1,50 @@
+// @flow
+
+import { emptyPage } from '../src/spring-models';
+import type { Page } from '../src/spring-models';
+
+import { makeResource } from '../src/resource';
+
+class Pokemon {
+  id: number;
+  name: string;
+  types: Array<string>;
+
+  save: () => Promise<Pokemon>;
+  remove: () => Promise<Pokemon>;
+
+  static one: (id: number, queryParams: ?Object) => Promise<Pokemon>;
+  static list: (queryParams: ?Object) => Promise<Array<Pokemon>>;
+  static page: (queryParams: ?Object) => Promise<Page<Pokemon>>;
+}
+
+makeResource(Pokemon, 'api/pokemon');
+
+class Bicycle {
+  id: number;
+  brand: string;
+
+  save: () => Promise<Bicycle>;
+  remove: () => Promise<Bicycle>;
+
+  static one: (id: number, queryParams: ?Object) => Promise<Bicycle>;
+  static list: (queryParams: ?Object) => Promise<Array<Bicycle>>;
+  static page: (queryParams: ?Object) => Promise<Page<Bicycle>>;
+}
+
+makeResource(Bicycle, 'api/bicycle');
+
+/* 
+  This test is designed to trip flow, not to actually test any code.
+  The emptyPage had a bug where it was not recognized as being a 
+  Page<T>.
+*/
+describe('emptyPage', () => {
+  it('should understand that emptyPage is of type Page<T>', () => {
+    const pokemonPage: Page<Pokemon> = emptyPage;
+    const bicyclePage: Page<Bicycle> = emptyPage;
+
+    const bicycleContent: Array<Bicycle> = emptyPage.content;
+    const pokemonContent: Array<Pokemon> = emptyPage.content;
+  });
+});


### PR DESCRIPTION
…Page<T>.

This caused flow errors when using the `emptyPage` more than once in
an application. This caused errors such as:

```
39:     const pokemonPage: Page<Pokemon> = emptyPage;
                                         ^^^^^^^ Pokemon. This type is incompatible with
40:     const bicyclePage: Page<Bicycle> = emptyPage;
                                         ^^^^^^^ Bicycle
                                         ```

The fix was to type it as a Page<*> instead. Added a test which makes
sure that flow is not bothered by multiple uses of `emptyPage`.

Closes #6.