### PR TITLE
Bugfix: emptyPage was not recognized as Page<T> when used more than o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.0] - 2018-04-16
+- Fixed a bug which caused the `emptyPage` from the spring-models not
+to be recognized as being of type Page<T>. `emptyPage` is now a function
+this way flow recognizes that each time `emptyPage` is called it returns 
+a new type of Page.
+
 ## [1.0.1] - 2018-02-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mad-spring-connect",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Connecting with a Spring REST APIs in a domain friendly manner",
   "files": [
     "lib"

--- a/src/spring-models.js
+++ b/src/spring-models.js
@@ -19,13 +19,15 @@ export type Page<T> = {
  * Represents an empty Page useful for initializing variables while
  * waiting for the actual Page to be retrieved.
  */
-export const emptyPage: Page<*> = Object.freeze({
-  content: [],
-  last: true,
-  totalElements: 0,
-  totalPages: 0,
-  size: 0,
-  number: 0,
-  first: true,
-  numberOfElements: 0
-});
+export function emptyPage<T>(): Page<T> { 
+  return Object.freeze({
+    content: [],
+    last: true,
+    totalElements: 0,
+    totalPages: 0,
+    size: 0,
+    number: 0,
+    first: true,
+    numberOfElements: 0
+  });
+}

--- a/tests/spring-models.test.js
+++ b/tests/spring-models.test.js
@@ -41,10 +41,10 @@ makeResource(Bicycle, 'api/bicycle');
 */
 describe('emptyPage', () => {
   it('should understand that emptyPage is of type Page<T>', () => {
-    const pokemonPage: Page<Pokemon> = emptyPage;
-    const bicyclePage: Page<Bicycle> = emptyPage;
+    const pokemonPage: Page<Pokemon> = emptyPage();
+    const bicyclePage: Page<Bicycle> = emptyPage();
 
-    const bicycleContent: Array<Bicycle> = emptyPage.content;
-    const pokemonContent: Array<Pokemon> = emptyPage.content;
+    const bicycleContent: Array<Bicycle> = emptyPage().content;
+    const pokemonContent: Array<Pokemon> = emptyPage().content;
   });
 });


### PR DESCRIPTION
…nce.

The reason for this is unclear to me, but changing `emptyPage` to a
function seems to work, because flow now sees that a new object is
created every time the `emptyPage` function is called.

Hopefuly this should fix #6 once and for all.

Also released v2.0.0.