### PR TITLE
Feature: `put`, `post` and `patch` can work `FormData` as the payload.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,13 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module'
   },
-  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
+  extends: ['plugin:@typescript-eslint/recommended'],
   plugins: ['@typescript-eslint'],
   rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
     indent: 'off',
     '@typescript-eslint/indent': ['error', 2],
+    '@typescript-eslint/no-use-before-define': ['off'],
   }
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0] - 2019-08-12
+- The `post`, `patch` and `put` payload parameter can now be a `FormData`. 
+  Useful for totally controlling the `body` for example when uploading.
+
+- Updated to TypeScript `3.5.3` had to make `QueryParams` the correct
+  type as needed by `query-string`'s `stringify` method.
+
+- Exposed `Method`, `MiddlewareDetailInfo`, `QueryParams` in the index.
+
 ## [3.1.2] - 2019-08-06
 
 - Renamed to @42.nl/spring-connect

--- a/docs/introduction/usage.md
+++ b/docs/introduction/usage.md
@@ -302,6 +302,9 @@ post('api/pokemon', { name: 'bulbasaur' }).then(json => {
 });
 ```
 
+The `payload` can also be a `FormData` object, useful for when uploading
+files: See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
+
 ### put
 
 The **_put_** function does a PUT request to the given url, with the given payload.
@@ -314,6 +317,9 @@ put('api/pokemon/1', { id: 1, name: 'bulbasaur' }).then(json => {
 });
 ```
 
+The `payload` can also be a `FormData` object, useful for when uploading
+files: See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
+
 ### patch
 
 The **_patch_** function does a PATCH request to the given url, with the given payload.
@@ -325,6 +331,9 @@ patch('api/pokemon/1', { id: 1, name: 'bulbasaur' }).then(json => {
   // Do something with the json here
 });
 ```
+
+The `payload` can also be a `FormData` object, useful for when uploading
+files: See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
 
 ### remove
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/spring-connect",
-  "version": "3.1.2",
+  "version": "3.2.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4845,9 +4845,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/spring-connect",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Connecting with a Spring REST APIs in a domain friendly manner",
   "files": [
     "lib"
@@ -40,7 +40,7 @@
     "jest": "24.5.0",
     "prettier": "1.16.4",
     "ts-jest": "24.0.0",
-    "typescript": "3.3.3333"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "start": "jest test --watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { default as Middleware, checkStatus, parseJSON } from './middleware';
+export { default as Middleware, checkStatus, parseJSON, Method, MiddlewareDetailInfo } from './middleware';
 export { default as Config, configureMadConnect, getFetch } from './config';
-export { get, post, put, patch, remove } from './request';
+export { get, post, put, patch, remove, QueryParams, Payload } from './request';
 export { makeResource, Resource } from './resource';
 export { Page, emptyPage } from './spring-models';
 export { makeInstance, buildUrl, applyMiddleware } from './utils';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,20 @@
 import { QueryParams } from './request';
 
+export enum Method {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+  PATCH = 'PATCH',
+}
+
+export interface MiddlewareDetailInfo {
+  url: string;
+  method: Method;
+  queryParams?: QueryParams;
+  payload?: object;
+}
+
 /**
  * Middleware is a function which takes a Promise, and optionally
  * the url and options of the request and returns a new promise and
@@ -26,20 +41,6 @@ import { QueryParams } from './request';
  * }
  * ```
  */
-export enum Method {
-  GET = 'GET',
-  POST = 'POST',
-  PUT = 'PUT',
-  DELETE = 'DELETE',
-  PATCH = 'PATCH',
-}
-export interface MiddlewareDetailInfo {
-  url: string;
-  method: Method;
-  queryParams?: QueryParams;
-  payload?: object;
-}
-
 export type Middleware = (middleware: Promise<any>, options: MiddlewareDetailInfo) => Promise<any>;
 
 /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,7 +2,10 @@ import { buildUrl, applyMiddleware } from './utils';
 import { getFetch } from './config';
 import { Method } from './middleware';
 
-export type QueryParams = object;
+export interface QueryParams {
+  [key: string]: unknown;
+}
+export type Payload = object | FormData;
 
 /**
  * Does a GET request to the given url, with the query params if
@@ -39,20 +42,14 @@ export function get(url: string, queryParams?: QueryParams): Promise<any> {
  * ```
  *
  * @export
- * @param {string} url  The url you want to send a POST request to.
- * @param {object} payload The payload you want to send to the server.
+ * @param {string} url The url you want to send a POST request to.
+ * @param {Payload} payload The payload you want to send to the server.
  * @returns {Promise} Returns a Promise, the content of the promise depends on the configured middleware.
  */
-export function post(url: string, payload: object): Promise<any> {
-  let method = Method.POST;
+export function post(url: string, payload: Payload): Promise<any> {
+  const method = Method.POST;
 
-  const options = {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method,
-    body: JSON.stringify(payload),
-  };
+  const options = optionsForMethodAndPayload(method, payload);
 
   return applyMiddleware(getFetch()(url, options), { url, payload, method });
 }
@@ -70,20 +67,14 @@ export function post(url: string, payload: object): Promise<any> {
  * ```
  *
  * @export
- * @param {string} url  The url you want to send a PUT request to.
- * @param {Object} payload The payload you want to send to the server.
+ * @param {string} url The url you want to send a PUT request to.
+ * @param {Payload} payload The payload you want to send to the server.
  * @returns {Promise} Returns a Promise, the content of the promise depends on the configured middleware.
  */
-export function put(url: string, payload: object): Promise<any> {
-  let method = Method.PUT;
+export function put(url: string, payload: Payload): Promise<any> {
+  const method = Method.PUT;
 
-  const options = {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method,
-    body: JSON.stringify(payload),
-  };
+  const options = optionsForMethodAndPayload(method, payload);
 
   return applyMiddleware(getFetch()(url, options), { url, payload, method });
 }
@@ -102,19 +93,13 @@ export function put(url: string, payload: object): Promise<any> {
  *
  * @export
  * @param {string} url  The url you want to send a PATCH request to.
- * @param {Object} payload The payload you want to send to the server.
+ * @param {Payload} payload The payload you want to send to the server.
  * @returns {Promise} Returns a Promise, the content of the promise depends on the configured middleware.
  */
-export function patch(url: string, payload: object): Promise<any> {
-  let method = Method.PATCH;
+export function patch(url: string, payload: Payload): Promise<any> {
+  const method = Method.PATCH;
 
-  const options = {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method,
-    body: JSON.stringify(payload),
-  };
+  const options = optionsForMethodAndPayload(method, payload);
 
   return applyMiddleware(getFetch()(url, options), { url, payload, method });
 }
@@ -139,7 +124,7 @@ export function patch(url: string, payload: object): Promise<any> {
  * @returns {Promise} Returns a Promise, the content of the promise depends on the configured middleware.
  */
 export function remove(url: string): Promise<any> {
-  let method = Method.DELETE;
+  const method = Method.DELETE;
 
   const options = {
     headers: {
@@ -152,4 +137,21 @@ export function remove(url: string): Promise<any> {
     url,
     method,
   });
+}
+
+export function optionsForMethodAndPayload(method: Method, payload: Payload): RequestInit {
+  if (payload instanceof FormData) {
+    return {
+      body: payload,
+      method,
+    };
+  } else {
+    return {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      method,
+    };
+  }
 }

--- a/tests/request.test.ts
+++ b/tests/request.test.ts
@@ -193,6 +193,47 @@ describe('requests', () => {
         done();
       }
     });
+
+    test('200: custom payload', async done => {
+      const options = {
+        body: { id: 1 },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+      fetchMock.post('api/pokemon', options);
+
+      const payload = new FormData();
+
+      const blob = new Blob([JSON.stringify({ name: 'bulbasaur' })], {
+        type: 'application/json',
+      });
+      payload.append('pokemon', blob);
+
+      const json = await post('api/pokemon', payload);
+      expect(json).toEqual({ id: 1 });
+
+      const fetchOptions = fetchMock.lastOptions();
+      // @ts-ignore
+      expect(fetchOptions.headers).toBe(undefined);
+      expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
+        url: 'api/pokemon',
+        method: 'POST',
+        payload,
+      });
+
+      // @ts-ignore
+      for (let entry of fetchOptions.body.entries()) {
+        const [key, value] = entry;
+
+        expect(key).toBe('pokemon');
+
+        const reader = new FileReader();
+        reader.onload = function() {
+          expect(reader.result).toBe(`{"name":"bulbasaur"}`);
+          done();
+        };
+        reader.readAsText(value);
+      }
+    });
   });
 
   describe('put', () => {
@@ -272,6 +313,47 @@ describe('requests', () => {
         done();
       }
     });
+
+    test('200: custom payload', async done => {
+      const options = {
+        body: { id: 1 },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+      fetchMock.put('api/pokemon', options);
+
+      const payload = new FormData();
+
+      const blob = new Blob([JSON.stringify({ name: 'bulbasaur' })], {
+        type: 'application/json',
+      });
+      payload.append('pokemon', blob);
+
+      const json = await put('api/pokemon', payload);
+      expect(json).toEqual({ id: 1 });
+
+      const fetchOptions = fetchMock.lastOptions();
+      // @ts-ignore
+      expect(fetchOptions.headers).toBe(undefined);
+      expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
+        url: 'api/pokemon',
+        method: 'PUT',
+        payload,
+      });
+
+      // @ts-ignore
+      for (let entry of fetchOptions.body.entries()) {
+        const [key, value] = entry;
+
+        expect(key).toBe('pokemon');
+
+        const reader = new FileReader();
+        reader.onload = function() {
+          expect(reader.result).toBe(`{"name":"bulbasaur"}`);
+          done();
+        };
+        reader.readAsText(value);
+      }
+    });
   });
 
   describe('patch', () => {
@@ -349,6 +431,47 @@ describe('requests', () => {
         });
 
         done();
+      }
+    });
+
+    test('200: custom payload', async done => {
+      const options = {
+        body: { id: 1 },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+      fetchMock.patch('api/pokemon', options);
+
+      const payload = new FormData();
+
+      const blob = new Blob([JSON.stringify({ name: 'bulbasaur' })], {
+        type: 'application/json',
+      });
+      payload.append('pokemon', blob);
+
+      const json = await patch('api/pokemon', payload);
+      expect(json).toEqual({ id: 1 });
+
+      const fetchOptions = fetchMock.lastOptions();
+      // @ts-ignore
+      expect(fetchOptions.headers).toBe(undefined);
+      expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
+        url: 'api/pokemon',
+        method: 'PATCH',
+        payload,
+      });
+
+      // @ts-ignore
+      for (let entry of fetchOptions.body.entries()) {
+        const [key, value] = entry;
+
+        expect(key).toBe('pokemon');
+
+        const reader = new FileReader();
+        reader.onload = function() {
+          expect(reader.result).toBe(`{"name":"bulbasaur"}`);
+          done();
+        };
+        reader.readAsText(value);
       }
     });
   });


### PR DESCRIPTION
Before the `payload` had to be a plain `object`, it now accepts `Object`
and `FormData`. When the payload is a `FormData` it is used as the `body`
to the `fetch` and the headers are not set to: `Content-Type': 'application/json'`.

The types of the `Method`, `MiddlewareDetailInfo`, `QueryParams` are
now exported in the index for easy access.

Also bumped TypeScript to the latest version.

Closes #11.