### PR TITLE
Improvement: the `one` method now accepts a string or a number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.0] - 2019-09-11
+- The `one` method now accepts a string for the id as well.
+
 ## [3.2.0] - 2019-08-12
 - The `post`, `patch` and `put` payload parameter can now be a `FormData`. 
   Useful for totally controlling the `body` for example when uploading.

--- a/docs/guide/2. resource.md
+++ b/docs/guide/2. resource.md
@@ -17,11 +17,11 @@ First we must define what a Resource means: A resource is a class
 which extends the following class:
 
 ```ts
-declare class BaseResource<T> {
+export declare class Resource<T> {
   public id?: number;
   public save(): Promise<T>;
   public remove(): Promise<T>;
-  public static one<T>(id: number, queryParams?: QueryParams): Promise<T>;
+  public static one<T>(id: number | string, queryParams?: QueryParams): Promise<T>;
   public static findOne<T>(queryParams: QueryParams): Promise<T | null>;
   public static list<T>(queryParams?: QueryParams): Promise<T[]>;
   public static page<T>(queryParams?: QueryParams): Promise<Page<T>>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/spring-connect",
-  "version": "3.2.0-beta.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1498,10 +1498,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@42.nl/spring-connect",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Connecting with a Spring REST APIs in a domain friendly manner",
   "files": [
     "lib"

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -8,7 +8,7 @@ export declare class Resource<T> {
   public id?: number;
   public save(): Promise<T>;
   public remove(): Promise<T>;
-  public static one<T>(id: number, queryParams?: QueryParams): Promise<T>;
+  public static one<T>(id: number | string, queryParams?: QueryParams): Promise<T>;
   public static findOne<T>(queryParams: QueryParams): Promise<T | null>;
   public static list<T>(queryParams?: QueryParams): Promise<T[]>;
   public static page<T>(queryParams?: QueryParams): Promise<Page<T>>;
@@ -89,12 +89,12 @@ export function makeResource<T>(baseUrl: string): typeof Resource {
      * ```
      *
      * @static
-     * @param {number} id The id of the Resource you want to retrieve
+     * @param {number | string} id The id of the Resource you want to retrieve
      * @param {QueryParams} queryParams Optional query params for the url
      * @returns {Promise<T>} A Promise returning the Resource of type T.
      *
      */
-    public static async one<T>(id: number, queryParams?: QueryParams): Promise<T> {
+    public static async one<T>(id: number | string, queryParams?: QueryParams): Promise<T> {
       const json = await get(`${baseUrl}/${id}`, queryParams);
       // @ts-ignore
       return makeInstance(this, json);
@@ -136,7 +136,7 @@ export function makeResource<T>(baseUrl: string): typeof Resource {
      * ```
      *
      * @static
-     * @param {Object} queryParams Optional query params for the url
+     * @param {QueryParams} queryParams Optional query params for the url
      * @returns {Promise<Array<T>>} A Promise returning the Resource of type Array<T>.
      *
      * @memberOf Resource
@@ -157,7 +157,7 @@ export function makeResource<T>(baseUrl: string): typeof Resource {
      * ```
      *
      * @static
-     * @param {Object} queryParams Optional query params for the url
+     * @param {QueryParams} queryParams Optional query params for the url
      * @returns {Promise<Page<T>>} A Promise returning the Resource of type Page<T>.
      */
     public static async page<T>(queryParams?: QueryParams): Promise<Page<T>> {

--- a/tests/resource.test.ts
+++ b/tests/resource.test.ts
@@ -166,6 +166,28 @@ describe('Resource', () => {
 
       done();
     });
+
+    test('with id which is a string', async done => {
+      const response = {
+        body: {
+          id: 1,
+          name: 'bulbasaur',
+          types: ['poison', 'grass'],
+        },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+
+      fetchMock.get('api/pokemon/1', response);
+
+      const pokemon: Pokemon = await Pokemon.one('1');
+
+      expect(pokemon instanceof Pokemon).toBe(true);
+      expect(pokemon.id).toBe(1);
+      expect(pokemon.name).toBe('bulbasaur');
+      expect(pokemon.types).toEqual(['poison', 'grass']);
+
+      done();
+    });
   });
 
   describe('findOne', () => {


### PR DESCRIPTION
This way the user is not forced to parse a string to a number when
retrieving the `id` from a url path param which is always a string.

Updated the `2. resource.md` documentation so it matches the `Resource`
class exactly. Also fixed some errors in the type of `QueryParam` in the
doc comments.

Also fixed some audit warnings.

Closes #24.