### PR TITLE
feat: It is now possible to have a custom mapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,4 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
+# We no longer use the CHANGELOG instead we use releases.
 
 ## [4.0.0] - 2019-09-11
 - The `makeResource` should now be used like this: 

--- a/docs/guide/2. resource.md
+++ b/docs/guide/2. resource.md
@@ -33,7 +33,7 @@ Lets say we want to define a Pokemon resource, we would go about it in the follo
 ```ts
 import { makeResource, Page } from '@42.nl/spring-connect';
 
-export default class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+export default class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
   /* 
     These are the properties of the pokemon which it has when it is
     fetched from the back-end. Note that `!`, TypeScript needs this

--- a/docs/guide/5. customize.md
+++ b/docs/guide/5. customize.md
@@ -10,7 +10,62 @@ previous:
   name: Mutation
 ---
 
-## 5.1 Adding custom methods on Pokemon
+## 5.1 Adding a custom mapper
+
+By default every JSON which is received by the `one`, `findOne`, `page`
+and `list` is mapped by this function:
+
+```ts
+function defaultMapper<T>(json: JSON, Class: { new (): T }): T {
+  return makeInstance(Class, json);
+}
+```
+
+It simply makes an instance of the class by calling the `makeInstance`
+util function with the retrieved JSON.
+
+Sometimes you want to override the default mapper, in the example
+below we create a `Pokeball` which contains a pokemon. What we want
+is to make the pokemon an actual instance of `Pokemon`. We also want
+to store the time of retrieval from the back-end.
+
+```ts
+class Pokeball extends makeResource<Pokeball>({
+  baseUrl: '/api/pokeball',
+  mapper: pokeballMapper,
+}) {
+  public id?: number;
+
+  /*
+    In the actual JSON response pokemon is simply an object.
+    But our custom mapper makes sure it will also get mapped.
+  */
+  public pokemon!: Pokemon;
+
+  /* 
+    Does not really exist on the back-end but is filled by the
+    custom mapper.
+  */
+  public retrievedAt!: Date;
+}
+
+function pokeballMapper(json: any, Class: { new (): Pokeball }): Pokeball {
+  const pokeball = makeInstance(Class, json);
+  /* Add a completely new field */
+  pokeball.retrievedAt = new Date();
+
+  /* Make the fetched pokemon an actual instance of Pokemon */
+  pokeball.pokemon = makeInstance(Pokemon, pokeball.pokemon);
+
+  return pokeball;
+}
+```
+
+A custom mapper is useful for when the mapping for `one`, `findOne`, `page`
+and `list` is exactly the same. If they differ you should instead create
+custom methods instead, as explained below.
+
+## 5.2 Adding custom methods on Pokemon
 
 For most situations the default Resource will work just fine, but sometimes you do want to extend and/or customize the available methods from `makeResource`.
 
@@ -21,7 +76,7 @@ building blocks to easily create your own custom methods.
 See the [Utils](https://42bv.github.io/mad-spring-connect/utils) section for the
 helper functions. It is recommended that you use these functions to help you customize your Resource.
 
-### 5.1.1 adding instance methods
+### 5.2.1 adding instance methods
 
 Say you want to add method which retrieves all the evolutions of a Pokémon,
 this is how you do it:
@@ -29,7 +84,7 @@ this is how you do it:
 ```ts
 import { get, makeInstance, makeResource } from '@42.nl/spring-connect';
 
-const baseUrl = 'api/pokemon';
+const baseUrl = '/api/pokemon';
 
 class Pokemon extends makeResource<Pokemon>(baseUrl) {
   /* shortend the definition of the pokemon class. */
@@ -56,14 +111,14 @@ const bulbasaur = await pokemon.one(1);
 const evolutions = await pokemon.evolutions();
 ```
 
-### 5.1.2 adding static methods
+### 5.2.2 adding static methods
 
 You could also solve this problem with a static method:
 
 ```ts
 import { get, makeInstance, makeResource } from '@42.nl/spring-connect';
 
-const baseUrl = 'api/pokemon';
+const baseUrl = '/api/pokemon';
 
 class Pokemon extends makeResource<Pokemon>(baseUrl) {
   /* shortend the definition of the pokemon class. */
@@ -85,13 +140,13 @@ Which you could use like this:
 const evolutions = await Pokemon.evolutions(1);
 ```
 
-## 5.2 Overriding methods on Pokemon
+## 5.3 Overriding methods on Pokemon
 
 Sometimes you will find that the default implementations does not match
 your domain. For example there might be a difference between an Entity
 in a List / Page or when it is retrieved alone.
 
-### 5.2.1 Overriding instance methods
+### 5.3.1 Overriding instance methods
 
 You can override `save` and `remove` by simply defining them.
 
@@ -101,7 +156,7 @@ This example defines its own custom `save` implementation:
 import { makeResource, post, put, Page } from '@42.nl/spring-connect';
 import { merge } from 'lodash';
 
-const baseUrl = 'api/pokemon';
+const baseUrl = '/api/pokemon';
 
 export default class Pokemon extends makeResource<Pokemon>(baseUrl) {
   id!: number;
@@ -122,7 +177,7 @@ export default class Pokemon extends makeResource<Pokemon>(baseUrl) {
 }
 ```
 
-### 5.2.2 Overriding static methods
+### 5.3.2 Overriding static methods
 
 You can override `one`, `findOne`, `list` and `page` by simply defining them.
 
@@ -137,7 +192,7 @@ export interface PagePokemon {
   name: string;
 }
 
-const baseUrl = 'api/pokemon';
+const baseUrl = '/api/pokemon';
 
 export default class Pokemon extends makeResource(baseUrl)<Pokemon> {
   id!: number;

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -119,7 +119,7 @@ set the middleware:
 ```ts
 import { configureMadConnect, checkStatus, parseJSON } from '@42.nl/spring-connect';
 
-import { authFetch } from 'redux-mad-authentication';
+import { authFetch } from '@42.nl/authentication';
 
 configureMadConnect({
   fetch: authFetch,

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -20,7 +20,7 @@ For example:
 ```ts
 import { get } from '@42.nl/spring-connect';
 
-get('api/pokemon', { page: 1 }).then(json => {
+get('/api/pokemon', { page: 1 }).then(json => {
   // Do something with the json here
 });
 ```
@@ -35,7 +35,7 @@ Then gives the result to the configured middleware
 for processing.
 
 ```ts
-post('api/pokemon', { name: 'bulbasaur' }).then(json => {
+post('/api/pokemon', { name: 'bulbasaur' }).then(json => {
   // Do something with the json here
 });
 ```
@@ -49,7 +49,7 @@ The **_put_** function does a `PUT` request to the given url, with the given pay
 It then gives the result to the configured middleware for processing.
 
 ```ts
-put('api/pokemon/1', { id: 1, name: 'bulbasaur' }).then(json => {
+put('/api/pokemon/1', { id: 1, name: 'bulbasaur' }).then(json => {
   // Do something with the json here
 });
 ```
@@ -64,7 +64,7 @@ Then gives the result to the configured middleware
 for processing.
 
 ```ts
-patch('api/pokemon/1', { id: 1, name: 'bulbasaur' }).then(json => {
+patch('/api/pokemon/1', { id: 1, name: 'bulbasaur' }).then(json => {
   // Do something with the json here
 });
 ```
@@ -81,7 +81,7 @@ for processing.
 ```ts
 import { remove } from '@42.nl/spring-connect';
 
-remove('api/pokemon/1').then(() => {
+remove('/api/pokemon/1').then(() => {
   // Do something here.
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { default as Middleware, checkStatus, parseJSON, Method, MiddlewareDetailInfo } from './middleware';
 export { default as Config, configureMadConnect, getFetch } from './config';
 export { get, post, put, patch, remove, QueryParams, Payload } from './request';
-export { makeResource } from './resource';
+export { makeResource, MakeResourceConfig, Mapper } from './resource';
 export { Page, emptyPage } from './spring-models';
 export { makeInstance, buildUrl, applyMiddleware } from './utils';

--- a/src/request.ts
+++ b/src/request.ts
@@ -14,7 +14,7 @@ export type Payload = object | FormData;
  *
  * @example
  * ```js
- *  get('api/pokemon', { page: 1 }).then((json) => {
+ *  get('/api/pokemon', { page: 1 }).then((json) => {
  *   // Do something with the json here
  *  });
  * ```
@@ -36,7 +36,7 @@ export function get(url: string, queryParams?: QueryParams): Promise<any> {
  *
  * @example
  * ```js
- *  post('api/pokemon', { name: "bulbasaur" }).then((json) => {
+ *  post('/api/pokemon', { name: "bulbasaur" }).then((json) => {
  *    // Do something with the json here
  *  });
  * ```
@@ -61,7 +61,7 @@ export function post(url: string, payload: Payload): Promise<any> {
  *
  * @example
  * ```js
- *  put('api/pokemon/1', { id: 1, name: "bulbasaur" }).then((json) => {
+ *  put('/api/pokemon/1', { id: 1, name: "bulbasaur" }).then((json) => {
  *    // Do something with the json here
  *  });
  * ```
@@ -86,7 +86,7 @@ export function put(url: string, payload: Payload): Promise<any> {
  *
  * @example
  * ```js
- *  patch('api/pokemon/1', { id: 1, name: "bulbasaur" }).then((json) => {
+ *  patch('/api/pokemon/1', { id: 1, name: "bulbasaur" }).then((json) => {
  *    // Do something with the json here
  *  });;
  * ```
@@ -114,7 +114,7 @@ export function patch(url: string, payload: Payload): Promise<any> {
  *
  * @example
  * ```js
- *  remove('api/pokemon/1').then(() => {
+ *  remove('/api/pokemon/1').then(() => {
  *    // Do something here.
  *  });;
  * ```

--- a/tests/request.test.ts
+++ b/tests/request.test.ts
@@ -27,15 +27,15 @@ describe('requests', () => {
 
   describe('get', () => {
     test('200: without query parameters', async done => {
-      fetchMock.get('api/pokemon/1', {
+      fetchMock.get('/api/pokemon/1', {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
-      const json = await get('api/pokemon/1');
+      const json = await get('/api/pokemon/1');
       expect(json).toEqual({ id: 1 });
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon/1',
+        url: '/api/pokemon/1',
         method: 'GET',
         options: undefined,
       });
@@ -48,12 +48,12 @@ describe('requests', () => {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.get('api/pokemon?page=1', options);
+      fetchMock.get('/api/pokemon?page=1', options);
 
-      const json = await get('api/pokemon', { page: 1 });
+      const json = await get('/api/pokemon', { page: 1 });
       expect(json).toEqual({ id: 1 });
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon',
+        url: '/api/pokemon',
         method: 'GET',
         queryParams: {
           page: 1,
@@ -64,17 +64,17 @@ describe('requests', () => {
     });
 
     test('500: server error', async done => {
-      fetchMock.get('api/pokemon?page=1', 500);
+      fetchMock.get('/api/pokemon?page=1', 500);
 
       const options = { page: 1 };
       try {
-        await get('api/pokemon', options);
+        await get('/api/pokemon', options);
         fail();
       } catch (e) {
         expect(e.message).toBe('Internal Server Error');
         expect(e.response).not.toBe(undefined);
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon',
+          url: '/api/pokemon',
           method: 'GET',
           queryParams: {
             page: 1,
@@ -86,21 +86,21 @@ describe('requests', () => {
     });
 
     test('200: parse error', async done => {
-      fetchMock.get('api/pokemon?page=1', {
+      fetchMock.get('/api/pokemon?page=1', {
         body: '[]}{}]',
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
       const options = { page: 1 };
       try {
-        await get('api/pokemon', options);
+        await get('/api/pokemon', options);
         fail();
       } catch (e) {
         expect(e.message).toBe(
           'invalid json response body at /api/pokemon?page=1 reason: Unexpected token } in JSON at position 2',
         );
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon',
+          url: '/api/pokemon',
           method: 'GET',
           queryParams: {
             page: 1,
@@ -118,9 +118,9 @@ describe('requests', () => {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.post('api/pokemon', options);
+      fetchMock.post('/api/pokemon', options);
 
-      const json = await post('api/pokemon', { name: 'bulbasaur' });
+      const json = await post('/api/pokemon', { name: 'bulbasaur' });
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
@@ -129,7 +129,7 @@ describe('requests', () => {
       // @ts-ignore
       expect(fetchOptions.headers['Content-Type']).toBe('application/json');
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon',
+        url: '/api/pokemon',
         method: 'POST',
         payload: {
           name: 'bulbasaur',
@@ -140,11 +140,11 @@ describe('requests', () => {
     });
 
     test('500: server error', async done => {
-      fetchMock.post('api/pokemon', 500);
+      fetchMock.post('/api/pokemon', 500);
 
       const payload = { name: 'bulbasaur' };
       try {
-        await post('api/pokemon', payload);
+        await post('/api/pokemon', payload);
         fail();
       } catch (e) {
         // @ts-ignore
@@ -156,7 +156,7 @@ describe('requests', () => {
         expect(e.message).toBe('Internal Server Error');
         expect(e.response).not.toBe(undefined);
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon',
+          url: '/api/pokemon',
           method: 'POST',
           payload,
         });
@@ -166,13 +166,13 @@ describe('requests', () => {
     });
 
     test('200: parse error', async done => {
-      fetchMock.post('api/pokemon', {
+      fetchMock.post('/api/pokemon', {
         body: '[]}{}]',
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
       try {
-        await post('api/pokemon', { name: 'bulbasaur' });
+        await post('/api/pokemon', { name: 'bulbasaur' });
         fail();
       } catch (e) {
         // @ts-ignore
@@ -185,7 +185,7 @@ describe('requests', () => {
           'invalid json response body at /api/pokemon reason: Unexpected token } in JSON at position 2',
         );
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon',
+          url: '/api/pokemon',
           method: 'POST',
           payload: { name: 'bulbasaur' },
         });
@@ -199,7 +199,7 @@ describe('requests', () => {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.post('api/pokemon', options);
+      fetchMock.post('/api/pokemon', options);
 
       const payload = new FormData();
 
@@ -208,14 +208,14 @@ describe('requests', () => {
       });
       payload.append('pokemon', blob);
 
-      const json = await post('api/pokemon', payload);
+      const json = await post('/api/pokemon', payload);
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
       // @ts-ignore
       expect(fetchOptions.headers).toBe(undefined);
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon',
+        url: '/api/pokemon',
         method: 'POST',
         payload,
       });
@@ -238,12 +238,12 @@ describe('requests', () => {
 
   describe('put', () => {
     test('200', async done => {
-      fetchMock.put('api/pokemon/1', {
+      fetchMock.put('/api/pokemon/1', {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
-      const json = await put('api/pokemon/1', { name: 'bulbasaur' });
+      const json = await put('/api/pokemon/1', { name: 'bulbasaur' });
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
@@ -252,7 +252,7 @@ describe('requests', () => {
       // @ts-ignore
       expect(fetchOptions.headers['Content-Type']).toBe('application/json');
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon/1',
+        url: '/api/pokemon/1',
         method: 'PUT',
         payload: { name: 'bulbasaur' },
       });
@@ -261,10 +261,10 @@ describe('requests', () => {
     });
 
     test('500: server error', async done => {
-      fetchMock.put('api/pokemon/1', 500);
+      fetchMock.put('/api/pokemon/1', 500);
 
       try {
-        await put('api/pokemon/1', { name: 'bulbasaur' });
+        await put('/api/pokemon/1', { name: 'bulbasaur' });
         fail();
       } catch (e) {
         // @ts-ignore
@@ -276,7 +276,7 @@ describe('requests', () => {
         expect(e.message).toBe('Internal Server Error');
         expect(e.response).not.toBe(undefined);
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon/1',
+          url: '/api/pokemon/1',
           method: 'PUT',
           payload: { name: 'bulbasaur' },
         });
@@ -286,13 +286,13 @@ describe('requests', () => {
     });
 
     test('200: parse error', async done => {
-      fetchMock.put('api/pokemon/1', {
+      fetchMock.put('/api/pokemon/1', {
         body: '[]}{}]',
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
       try {
-        await put('api/pokemon/1', { name: 'bulbasaur' });
+        await put('/api/pokemon/1', { name: 'bulbasaur' });
         fail();
       } catch (e) {
         // @ts-ignore
@@ -305,7 +305,7 @@ describe('requests', () => {
           'invalid json response body at /api/pokemon/1 reason: Unexpected token } in JSON at position 2',
         );
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon/1',
+          url: '/api/pokemon/1',
           method: 'PUT',
           payload: { name: 'bulbasaur' },
         });
@@ -319,7 +319,7 @@ describe('requests', () => {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.put('api/pokemon', options);
+      fetchMock.put('/api/pokemon', options);
 
       const payload = new FormData();
 
@@ -328,14 +328,14 @@ describe('requests', () => {
       });
       payload.append('pokemon', blob);
 
-      const json = await put('api/pokemon', payload);
+      const json = await put('/api/pokemon', payload);
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
       // @ts-ignore
       expect(fetchOptions.headers).toBe(undefined);
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon',
+        url: '/api/pokemon',
         method: 'PUT',
         payload,
       });
@@ -358,12 +358,12 @@ describe('requests', () => {
 
   describe('patch', () => {
     test('200', async done => {
-      fetchMock.patch('api/pokemon/1', {
+      fetchMock.patch('/api/pokemon/1', {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
-      const json = await patch('api/pokemon/1', { name: 'bulbasaur' });
+      const json = await patch('/api/pokemon/1', { name: 'bulbasaur' });
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
@@ -372,7 +372,7 @@ describe('requests', () => {
       // @ts-ignore
       expect(fetchOptions.headers['Content-Type']).toBe('application/json');
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon/1',
+        url: '/api/pokemon/1',
         method: 'PATCH',
         payload: { name: 'bulbasaur' },
       });
@@ -381,10 +381,10 @@ describe('requests', () => {
     });
 
     test('500: server error', async done => {
-      fetchMock.patch('api/pokemon/1', 500);
+      fetchMock.patch('/api/pokemon/1', 500);
 
       try {
-        await patch('api/pokemon/1', { name: 'bulbasaur' });
+        await patch('/api/pokemon/1', { name: 'bulbasaur' });
         fail();
       } catch (e) {
         // @ts-ignore
@@ -396,7 +396,7 @@ describe('requests', () => {
         expect(e.message).toBe('Internal Server Error');
         expect(e.response).not.toBe(undefined);
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon/1',
+          url: '/api/pokemon/1',
           method: 'PATCH',
           payload: { name: 'bulbasaur' },
         });
@@ -406,13 +406,13 @@ describe('requests', () => {
     });
 
     test('200: parse error', async done => {
-      fetchMock.patch('api/pokemon/1', {
+      fetchMock.patch('/api/pokemon/1', {
         body: '[]}{}]',
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
       try {
-        await patch('api/pokemon/1', { name: 'bulbasaur' });
+        await patch('/api/pokemon/1', { name: 'bulbasaur' });
         fail();
       } catch (e) {
         // @ts-ignore
@@ -425,7 +425,7 @@ describe('requests', () => {
           'invalid json response body at /api/pokemon/1 reason: Unexpected token } in JSON at position 2',
         );
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon/1',
+          url: '/api/pokemon/1',
           method: 'PATCH',
           payload: { name: 'bulbasaur' },
         });
@@ -439,7 +439,7 @@ describe('requests', () => {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.patch('api/pokemon', options);
+      fetchMock.patch('/api/pokemon', options);
 
       const payload = new FormData();
 
@@ -448,14 +448,14 @@ describe('requests', () => {
       });
       payload.append('pokemon', blob);
 
-      const json = await patch('api/pokemon', payload);
+      const json = await patch('/api/pokemon', payload);
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
       // @ts-ignore
       expect(fetchOptions.headers).toBe(undefined);
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon',
+        url: '/api/pokemon',
         method: 'PATCH',
         payload,
       });
@@ -478,19 +478,19 @@ describe('requests', () => {
 
   describe('remove', () => {
     test('200', async done => {
-      fetchMock.delete('api/pokemon/1', {
+      fetchMock.delete('/api/pokemon/1', {
         body: { id: 1 },
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
-      const json = await remove('api/pokemon/1');
+      const json = await remove('/api/pokemon/1');
       expect(json).toEqual({ id: 1 });
 
       const fetchOptions = fetchMock.lastOptions();
       // @ts-ignore
       expect(fetchOptions.headers['Content-Type']).toBe('application/json');
       expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-        url: 'api/pokemon/1',
+        url: '/api/pokemon/1',
         method: 'DELETE',
         payload: undefined,
       });
@@ -499,10 +499,10 @@ describe('requests', () => {
     });
 
     test('500: server error', async done => {
-      fetchMock.delete('api/pokemon/1', 500);
+      fetchMock.delete('/api/pokemon/1', 500);
 
       try {
-        await remove('api/pokemon/1');
+        await remove('/api/pokemon/1');
         fail();
       } catch (e) {
         // @ts-ignore
@@ -512,7 +512,7 @@ describe('requests', () => {
         expect(e.message).toBe('Internal Server Error');
         expect(e.response).not.toBe(undefined);
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon/1',
+          url: '/api/pokemon/1',
           method: 'DELETE',
           payload: undefined,
         });
@@ -522,13 +522,13 @@ describe('requests', () => {
     });
 
     test('200: parse error', async done => {
-      fetchMock.delete('api/pokemon/1', {
+      fetchMock.delete('/api/pokemon/1', {
         body: '[]}{}]',
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       });
 
       try {
-        await remove('api/pokemon/1');
+        await remove('/api/pokemon/1');
         fail();
       } catch (e) {
         // @ts-ignore
@@ -539,7 +539,7 @@ describe('requests', () => {
           'invalid json response body at /api/pokemon/1 reason: Unexpected token } in JSON at position 2',
         );
         expect(middleware.parseJSON).toHaveBeenCalledWith(expect.any(Promise), {
-          url: 'api/pokemon/1',
+          url: '/api/pokemon/1',
           method: 'DELETE',
           payload: undefined,
         });

--- a/tests/resource.test.ts
+++ b/tests/resource.test.ts
@@ -2,14 +2,31 @@ import fetchMock from 'fetch-mock';
 import { configureMadConnect } from '../src/config';
 import * as middleware from '../src/middleware';
 import { makeResource } from '../src/resource';
-
-class Pokemon extends makeResource<Pokemon>('api/pokemon') {
-  public id?: number;
-  public name!: string;
-  public types!: string[];
-}
+import { makeInstance } from '../src/utils';
 
 describe('Resource', () => {
+  class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
+    public id?: number;
+    public name!: string;
+    public types!: string[];
+  } 
+
+  class Pokeball extends makeResource<Pokeball>({
+    baseUrl: '/api/pokeball',
+    mapper: pokeballMapper,
+  }) {
+    public id?: number;
+    public pokemon!: Pokemon;
+    public retrievedAt!: Date;
+  }
+
+  function pokeballMapper(json: any, Class: { new (): Pokeball }): Pokeball {
+    const pokeball = makeInstance(Class, json);
+    pokeball.retrievedAt = new Date();
+    pokeball.pokemon = makeInstance(Pokemon, pokeball.pokemon);
+    return pokeball;
+  }
+
   beforeEach(() => {
     configureMadConnect({
       fetch: undefined,
@@ -32,7 +49,7 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.post('api/pokemon', response);
+      fetchMock.post('/api/pokemon', response);
 
       let pokemon = new Pokemon();
 
@@ -63,7 +80,7 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.put('api/pokemon/1', response);
+      fetchMock.put('/api/pokemon/1', response);
 
       const pokemon = new Pokemon();
       pokemon.id = 1;
@@ -87,7 +104,7 @@ describe('Resource', () => {
 
   describe('remove', () => {
     test('has id', async done => {
-      fetchMock.delete('api/pokemon/1', {
+      fetchMock.delete('/api/pokemon/1', {
         status: 204,
       });
 
@@ -132,7 +149,7 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon/1', response);
+      fetchMock.get('/api/pokemon/1', response);
 
       const pokemon = await Pokemon.one(1);
 
@@ -154,7 +171,7 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon/1?number=42', response);
+      fetchMock.get('/api/pokemon/1?number=42', response);
 
       const pokemon = await Pokemon.one(1, { number: 42 });
 
@@ -176,9 +193,38 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon/1', response);
+      fetchMock.get('/api/pokemon/1', response);
 
       const pokemon = await Pokemon.one('1');
+
+      expect(pokemon instanceof Pokemon).toBe(true);
+      expect(pokemon.id).toBe(1);
+      expect(pokemon.name).toBe('bulbasaur');
+      expect(pokemon.types).toEqual(['poison', 'grass']);
+
+      done();
+    });
+
+    test('with custom mapper', async done => {
+      const response = {
+        id: 1,
+        pokemon: {
+          id: 1,
+          name: 'bulbasaur',
+          types: ['poison', 'grass'],
+        },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+
+      fetchMock.get('/api/pokeball/1', response);
+
+      const pokeball = await Pokeball.one(1);
+
+      expect(pokeball instanceof Pokeball).toBe(true);
+      expect(pokeball.id).toBe(1);
+      expect(pokeball.retrievedAt instanceof Date).toBe(true);
+
+      const pokemon = pokeball.pokemon;
 
       expect(pokemon instanceof Pokemon).toBe(true);
       expect(pokemon.id).toBe(1);
@@ -196,7 +242,7 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon?name=bulbasaur', response);
+      fetchMock.get('/api/pokemon?name=bulbasaur', response);
 
       const pokemon = await Pokemon.findOne({ name: 'bulbasaur' });
 
@@ -215,11 +261,44 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon?name=bulbasaur', response);
+      fetchMock.get('/api/pokemon?name=bulbasaur', response);
 
       const pokemon = await Pokemon.findOne({ name: 'bulbasaur' });
 
       if (pokemon) {
+        expect(pokemon instanceof Pokemon).toBe(true);
+        expect(pokemon.id).toBe(1);
+        expect(pokemon.name).toBe('bulbasaur');
+        expect(pokemon.types).toEqual(['poison', 'grass']);
+      } else {
+        done.fail();
+      }
+
+      done();
+    });
+
+    test('with custom mapper', async done => {
+      const response = {
+        id: 1,
+        pokemon: {
+          id: 1,
+          name: 'bulbasaur',
+          types: ['poison', 'grass'],
+        },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+
+      fetchMock.get('/api/pokeball?name=bulbasaur', response);
+
+      const pokeball = await Pokeball.findOne({ name: 'bulbasaur' });
+
+      if (pokeball) {
+        const pokemon = pokeball.pokemon;
+
+        expect(pokeball instanceof Pokeball).toBe(true);
+        expect(pokeball.id).toBe(1);
+        expect(pokeball.retrievedAt instanceof Date).toBe(true);
+
         expect(pokemon instanceof Pokemon).toBe(true);
         expect(pokemon.id).toBe(1);
         expect(pokemon.name).toBe('bulbasaur');
@@ -254,7 +333,7 @@ describe('Resource', () => {
         ],
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.get('api/pokemon', response);
+      fetchMock.get('/api/pokemon', response);
 
       const pokemonList = await Pokemon.list();
 
@@ -301,9 +380,9 @@ describe('Resource', () => {
         ],
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
-      fetchMock.get('api/pokemon?filter=true', response);
+      fetchMock.get('/api/pokemon?filter=true', response);
 
-      const pokemonList= await Pokemon.list({ filter: true });
+      const pokemonList = await Pokemon.list({ filter: true });
 
       expect(pokemonList.length).toBe(3);
 
@@ -318,6 +397,81 @@ describe('Resource', () => {
       expect(ivysaur.id).toBe(2);
       expect(ivysaur.name).toBe('ivysaur');
       expect(ivysaur.types).toEqual(['grass']);
+
+      expect(venusaur instanceof Pokemon).toBe(true);
+      expect(venusaur.id).toBe(3);
+      expect(venusaur.name).toBe('venusaur');
+      expect(venusaur.types).toEqual(['grass', 'poison']);
+
+      done();
+    });
+
+    test('with custom mapper', async done => {
+      const response = {
+        body: [
+          {
+            id: 1,
+            pokemon: {
+              id: 1,
+              name: 'bulbasaur',
+              types: ['poison', 'grass'],
+            },
+          },
+
+          {
+            id: 2,
+            pokemon: {
+              id: 2,
+              name: 'ivysaur',
+              types: ['grass'],
+            },
+          },
+          {
+            id: 3,
+            pokemon: {
+              id: 3,
+              name: 'venusaur',
+              types: ['grass', 'poison'],
+            },
+          },
+        ],
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+      fetchMock.get('/api/pokeball', response);
+
+      const pokeballList = await Pokeball.list();
+
+      expect(pokeballList.length).toBe(3);
+
+      const [bulbasaurBall, ivysaurBall, venusaurBall] = pokeballList;
+
+      expect(bulbasaurBall instanceof Pokeball).toBe(true);
+      expect(bulbasaurBall.id).toBe(1);
+      expect(bulbasaurBall.retrievedAt instanceof Date).toBe(true);
+
+      expect(ivysaurBall instanceof Pokeball).toBe(true);
+      expect(ivysaurBall.id).toBe(2);
+      expect(ivysaurBall.retrievedAt instanceof Date).toBe(true);
+
+      expect(venusaurBall instanceof Pokeball).toBe(true);
+      expect(venusaurBall.id).toBe(3);
+      expect(venusaurBall.retrievedAt instanceof Date).toBe(true);
+
+      const bulbasaur = bulbasaurBall.pokemon;
+
+      expect(bulbasaur instanceof Pokemon).toBe(true);
+      expect(bulbasaur.id).toBe(1);
+      expect(bulbasaur.name).toBe('bulbasaur');
+      expect(bulbasaur.types).toEqual(['poison', 'grass']);
+
+      const ivysaur = ivysaurBall.pokemon;
+
+      expect(ivysaur instanceof Pokemon).toBe(true);
+      expect(ivysaur.id).toBe(2);
+      expect(ivysaur.name).toBe('ivysaur');
+      expect(ivysaur.types).toEqual(['grass']);
+
+      const venusaur = venusaurBall.pokemon;
 
       expect(venusaur instanceof Pokemon).toBe(true);
       expect(venusaur.id).toBe(3);
@@ -362,12 +516,12 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon', response);
+      fetchMock.get('/api/pokemon', response);
 
       const pokemonPage = await Pokemon.page();
 
       expect(pokemonPage.content.length).toBe(3);
-      
+
       const [bulbasaur, ivysaur, venusaur] = pokemonPage.content;
 
       expect(bulbasaur instanceof Pokemon).toBe(true);
@@ -388,7 +542,7 @@ describe('Resource', () => {
       done();
     });
 
-    test('without query params', async done => {
+    test('with query params', async done => {
       const content = [
         {
           id: 1,
@@ -421,7 +575,7 @@ describe('Resource', () => {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       };
 
-      fetchMock.get('api/pokemon?page=1', response);
+      fetchMock.get('/api/pokemon?page=1', response);
 
       const pokemonPage = await Pokemon.page({ page: 1 });
 
@@ -438,6 +592,93 @@ describe('Resource', () => {
       expect(ivysaur.id).toBe(2);
       expect(ivysaur.name).toBe('ivysaur');
       expect(ivysaur.types).toEqual(['grass']);
+
+      expect(venusaur instanceof Pokemon).toBe(true);
+      expect(venusaur.id).toBe(3);
+      expect(venusaur.name).toBe('venusaur');
+      expect(venusaur.types).toEqual(['grass', 'poison']);
+
+      done();
+    });
+
+    test('with custom mapper', async done => {
+      const content = [
+        {
+          id: 1,
+          pokemon: {
+            id: 1,
+            name: 'bulbasaur',
+            types: ['poison', 'grass'],
+          },
+        },
+
+        {
+          id: 2,
+          pokemon: {
+            id: 2,
+            name: 'ivysaur',
+            types: ['grass'],
+          },
+        },
+        {
+          id: 3,
+          pokemon: {
+            id: 3,
+            name: 'venusaur',
+            types: ['grass', 'poison'],
+          },
+        },
+      ];
+
+      const response = {
+        body: {
+          last: true,
+          totalElements: 3,
+          totalPages: 1,
+          size: 10,
+          number: 0,
+          first: true,
+          numberOfElements: 3,
+          content,
+        },
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      };
+
+      fetchMock.get('/api/pokeball?page=1', response);
+
+      const pokeballPage = await Pokeball.page({ page: 1 });
+
+      expect(pokeballPage.content.length).toBe(3);
+
+      const [bulbasaurBall, ivysaurBall, venusaurBall] = pokeballPage.content;
+
+      expect(bulbasaurBall instanceof Pokeball).toBe(true);
+      expect(bulbasaurBall.id).toBe(1);
+      expect(bulbasaurBall.retrievedAt instanceof Date).toBe(true);
+
+      expect(ivysaurBall instanceof Pokeball).toBe(true);
+      expect(ivysaurBall.id).toBe(2);
+      expect(ivysaurBall.retrievedAt instanceof Date).toBe(true);
+
+      expect(venusaurBall instanceof Pokeball).toBe(true);
+      expect(venusaurBall.id).toBe(3);
+      expect(venusaurBall.retrievedAt instanceof Date).toBe(true);
+
+      const bulbasaur = bulbasaurBall.pokemon;
+
+      expect(bulbasaur instanceof Pokemon).toBe(true);
+      expect(bulbasaur.id).toBe(1);
+      expect(bulbasaur.name).toBe('bulbasaur');
+      expect(bulbasaur.types).toEqual(['poison', 'grass']);
+
+      const ivysaur = ivysaurBall.pokemon;
+
+      expect(ivysaur instanceof Pokemon).toBe(true);
+      expect(ivysaur.id).toBe(2);
+      expect(ivysaur.name).toBe('ivysaur');
+      expect(ivysaur.types).toEqual(['grass']);
+
+      const venusaur = venusaurBall.pokemon;
 
       expect(venusaur instanceof Pokemon).toBe(true);
       expect(venusaur.id).toBe(3);

--- a/tests/scenarios.test.ts
+++ b/tests/scenarios.test.ts
@@ -11,8 +11,10 @@ import { makeResource } from '../src/resource';
 
 // Test that we can add custom methods to the Resource
 describe('Scenario: "custom methods"', () => {
-  // Make sure each test can get a completely new class
-  class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+  // Make sure each test can get a completely new class, and
+  // test that Config can be an object with only a baseUrl and
+  // no mapper.
+  class Pokemon extends makeResource<Pokemon>({ baseUrl: '/api/pokemon' }) {
 
     public id?: number;
     public name!: string;
@@ -70,7 +72,7 @@ describe('Scenario: "custom methods"', () => {
         },
       ],
     };
-    fetchMock.get('api/pokemon/1/evolutions', response);
+    fetchMock.get('/api/pokemon/1/evolutions', response);
   });
 
   afterEach(() => {
@@ -148,7 +150,7 @@ describe('Scenario: "custom methods"', () => {
 describe('Scenario: "override methods"', () => {
   describe('instance methods', () => {
     test('save', async done => {
-      class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+      class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
         public id?: number;
         public name!: string;
@@ -177,7 +179,7 @@ describe('Scenario: "override methods"', () => {
     });
 
     test('remove', async done => {
-      class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+      class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
         public id?: number;
         public name!: string;
@@ -208,7 +210,7 @@ describe('Scenario: "override methods"', () => {
 
   describe('static methods', () => {
     test('one', async done => {
-      class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+      class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
         public id?: number;
         public name!: string;
@@ -229,7 +231,7 @@ describe('Scenario: "override methods"', () => {
     });
 
     test('list', async done => {
-      class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+      class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
         public id?: number;
         public name!: string;
@@ -250,7 +252,7 @@ describe('Scenario: "override methods"', () => {
     });
 
     test('page', async done => {
-      class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+      class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
         public id?: number;
         public name!: string;
@@ -274,7 +276,7 @@ describe('Scenario: "override methods"', () => {
 
 // Test that we can extend methods of the Resource
 describe('Scenario: "extend methods"', () => {
-  class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+  class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
     public id?: number;
     public name!: string;
@@ -312,7 +314,7 @@ describe('Scenario: "extend methods"', () => {
       },
     };
 
-    fetchMock.put('api/pokemon/1', response);
+    fetchMock.put('/api/pokemon/1', response);
 
     const pokemon = new Pokemon();
     pokemon.id = 1;
@@ -342,7 +344,7 @@ describe('Scenario: "extend methods"', () => {
       },
     };
 
-    fetchMock.get('api/pokemon/1', response);
+    fetchMock.get('/api/pokemon/1', response);
 
     const p = await Pokemon.one(1);
     expect(p.id).toBe(42);
@@ -355,7 +357,7 @@ describe('Scenario: "extend methods"', () => {
 test('Scenario: "custom success middleware"', async done => {
   let finished = false;
 
-  class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+  class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
     public id?: number;
     public name!: string;
@@ -387,7 +389,7 @@ test('Scenario: "custom success middleware"', async done => {
     data: { id: 1 },
     error: {},
   };
-  fetchMock.get('api/pokemon/1', response);
+  fetchMock.get('/api/pokemon/1', response);
 
   const pokemon = await Pokemon.one(1);
   expect(pokemon).toEqual({ id: 1 });
@@ -401,7 +403,7 @@ test('Scenario: "custom success middleware"', async done => {
 
 // Test that we can override middleware
 test('Scenario: "custom error middleware"', async done => {
-  class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+  class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
 
     public id?: number;
     public name!: string;
@@ -422,7 +424,7 @@ test('Scenario: "custom error middleware"', async done => {
     middleware: [middleware.checkStatus, middleware.parseJSON, customMiddleware],
   });
 
-  fetchMock.get('api/pokemon/1', { status: 400 });
+  fetchMock.get('/api/pokemon/1', { status: 400 });
 
   try {
     await Pokemon.one(1);

--- a/tests/spring-models.test.ts
+++ b/tests/spring-models.test.ts
@@ -1,13 +1,13 @@
 import { Page, emptyPage } from '../src/spring-models';
 import { makeResource } from '../src/resource';
 
-class Pokemon extends makeResource<Pokemon>('api/pokemon') {
+class Pokemon extends makeResource<Pokemon>('/api/pokemon') {
   public id!: number;
   public name!: string;
   public types!: string[];
 }
 
-class Bicycle extends makeResource<Pokemon>('api/bicycle') {
+class Bicycle extends makeResource<Bicycle>('/api/bicycle') {
   public id!: number;
   public brand!: string;
 }


### PR DESCRIPTION
Resource now accepts an configuration object, which can contain a
custom mapper. With the custom mapper it is possible to dynamically
add properties and to convert them.

For example:

```ts
class Pokeball extends makeResource<Pokeball>({
  baseUrl: '/api/pokeball',
  mapper: pokeballMapper,
}) {
  public id?: number;

  /*
    In the actual JSON response pokemon is simply an object.
    But our custom mapper makes sure it will also get mapped.
  */
  public pokemon!: Pokemon;

  /*
    Does not really exist on the back-end but is filled by the
    custom mapper.
  */
  public retrievedAt!: Date;
}

function pokeballMapper(json: any, Class: { new (): Pokeball }): Pokeball {
  const pokeball = makeInstance(Class, json);
  /* Add a completely new field */
  pokeball.retrievedAt = new Date();

  /* Make the fetched pokemon an actual instance of Pokemon */
  pokeball.pokemon = makeInstance(Pokemon, pokeball.pokemon);

  return pokeball;
}
```

Closes #29.