### PR TITLE
feature: download file

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -123,3 +123,25 @@ export function remove<T>(url: string): Promise<T> {
     .delete<T>(url)
     .then((res) => res.data);
 }
+
+export async function downloadFile(url: string): Promise<void> {
+  const response = await getApi().get(url, {
+    responseType: 'blob'
+  });
+
+  const content = response.headers['content-disposition'];
+  if (!content) {
+    return;
+  }
+
+  const filename = content.split('filename=')[1].replace(/['"]+/g, '');
+  const link = document.createElement('a');
+  const href = URL.createObjectURL(response.data);
+
+  link.href = href;
+  link.setAttribute('download', filename);
+  link.click();
+
+  link.remove();
+  URL.revokeObjectURL(href);
+}


### PR DESCRIPTION
There is no easy way to facilitate a file download. You have to download the file using a request, create a link and click that link programmatically to send the file to the browser. I'd like to see that functionality in this library to have a robust and consistent solution.

Added downloadFile function to provide file downloads to the browser.

Closes #61