### PR TITLE
fix: export downloadFile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { get, post, put, patch, remove } from './request';
+export { get, post, put, patch, remove, downloadFile } from './request';
 export { default as Config, configureApi, getApi } from './config';
 export { makeResource, MakeResourceConfig, Mapper } from './resource';
 export { Page, emptyPage } from './spring-models';

--- a/src/request.ts
+++ b/src/request.ts
@@ -124,8 +124,27 @@ export function remove<T>(url: string): Promise<T> {
     .then((res) => res.data);
 }
 
-export async function downloadFile(url: string): Promise<void> {
-  const response = await getApi().get(url, {
+/**
+ * Does a GET request to the given url, with the query params if
+ * they are provided. Then causes the result file to be sent to
+ * the browser as download.
+ *
+ * @example
+ * ```js
+ *  downloadFile('/api/pokemon/pdf', { sort: 'id,asc' });
+ * ```
+ * @export
+ * @param {string} url The url you want to send a GET request to.
+ * @param {QueryParams} queryParams Optional query params as an object.
+ * @returns {Promise} Returns a Promise, the content of the promise depends on the configured middleware.
+ */
+export async function downloadFile(
+  url: string,
+  queryParams?: QueryParams
+): Promise<void> {
+  const finalUrl = buildUrl(url, queryParams);
+
+  const response = await getApi().get(finalUrl, {
     responseType: 'blob'
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,6 +6,7 @@ describe('index', () => {
       Object {
         "buildUrl": [Function],
         "configureApi": [Function],
+        "downloadFile": [Function],
         "emptyPage": [Function],
         "get": [Function],
         "getApi": [Function],


### PR DESCRIPTION
The downloadFile function is not exported to use outside the library yet The downloadFile function also does not support query parameters yet.

Added downloadFile to exports in index.
Changed downloadFile function to accept query parameters and build the query internally to make it work similar to the get function.